### PR TITLE
C-Style Array Declaration changed to Java Standard Declaration.

### DIFF
--- a/src/main/java/eventHandlers/KeyListener.java
+++ b/src/main/java/eventHandlers/KeyListener.java
@@ -5,7 +5,7 @@ import static org.lwjgl.glfw.GLFW.GLFW_RELEASE;
 
 public class KeyListener {
     private static KeyListener instance;
-    private boolean keyPressed[] = new boolean[350];
+    private boolean[] keyPressed = new boolean[350];
 
     private KeyListener() {
 

--- a/src/main/java/eventHandlers/MouseListener.java
+++ b/src/main/java/eventHandlers/MouseListener.java
@@ -7,7 +7,7 @@ public class MouseListener {
     private static MouseListener instance;
     private double scrollX, scrollY;
     private double xPos, yPos, lastY, lastX;
-    private boolean mouseButtonPressed[] = new boolean[3];
+    private boolean[] mouseButtonPressed = new boolean[3];
     private boolean isDragging;
 
     private MouseListener() {


### PR DESCRIPTION
Well, I'm not here to nitpick or anything but it's just that I wanted to contribute to open-source and I just found this to create a for and open a pull Request.

I'm following your game-engine with java tutorial on YouTube and when you used that declaration syntax I spent an hour to search for which one is better and found that the compiler is happy with both, but, I'll appericate if you use the java standard syntax that is in the oracle doumentation because it will be a problem for a beginner like me to understand the C like syntax, which has no history with C whatsoever.

I found this question on the [stackexchange ](https://softwareengineering.stackexchange.com/questions/331358/when-declaring-an-array-in-java-what-is-the-conventional-location-for-the-squar/331369) and this [article ](https://google.github.io/styleguide/javaguide.html#s4.8.3-arrays)by google, I guess, that says no _c-like array declations_.

I'll appreicate it if you help me increase my contribution count and accecpt the request.

I just changed the parts which I have covered in the tutorials that are the [engine event-handlers](https://github.com/ambrosiogabe/MinimalLWJGLEngine/tree/master/src/main/java/eventHandlers) you can change the rest.